### PR TITLE
Fix for Ldtp library on OSX

### DIFF
--- a/src/LDTPLibrary/keywords/_table.py
+++ b/src/LDTPLibrary/keywords/_table.py
@@ -20,7 +20,7 @@ try:
     import ldtp
 except ImportError:
     if sys.platform != "darwin":
-        raise ImportError
+        raise
     import atomac.ldtp as ldtp
 from .keywordgroup import KeywordGroup
 from ._exception import LdtpError
@@ -28,7 +28,7 @@ try:
     from ldtp.client_exception import LdtpExecutionError
 except ImportError:
     if sys.platform != "darwin":
-        raise ImportError
+        raise
     from atomac.ldtp.client_exception import LdtpExecutionError
 
 

--- a/src/LDTPLibrary/keywords/_table.py
+++ b/src/LDTPLibrary/keywords/_table.py
@@ -15,10 +15,21 @@ See http://ldtp.freedesktop.org/wiki/ for more information on LDTP.
 See 'LICENSE' in the source distribution for more information.
 """
 
-import ldtp
+import sys
+try:
+    import ldtp
+except ImportError:
+    if sys.platform != "darwin":
+        raise ImportError
+    import atomac.ldtp as ldtp
 from .keywordgroup import KeywordGroup
 from ._exception import LdtpError
-from ldtp.client_exception import LdtpExecutionError
+try:
+    from ldtp.client_exception import LdtpExecutionError
+except ImportError:
+    if sys.platform != "darwin":
+        raise ImportError
+    from atomac.ldtp.client_exception import LdtpExecutionError
 
 
 class TableKeywords(KeywordGroup):

--- a/src/LDTPLibrary/keywords/ldtpkw.py
+++ b/src/LDTPLibrary/keywords/ldtpkw.py
@@ -20,14 +20,14 @@ try:
     import ldtp
 except ImportError:
     if sys.platform != "darwin":
-        raise ImportError
+        raise
     import atomac.ldtp as ldtp
 from keywordgroup import KeywordGroup
 try:
     from ldtp.client_exception import LdtpExecutionError
 except ImportError:
     if sys.platform != "darwin":
-        raise ImportError
+        raise
     from atomac.ldtp.client_exception import LdtpExecutionError
 from _exception import LdtpError
 from robot.api.deco import keyword

--- a/src/LDTPLibrary/keywords/ldtpkw.py
+++ b/src/LDTPLibrary/keywords/ldtpkw.py
@@ -15,11 +15,21 @@ See http://ldtp.freedesktop.org/wiki/ for more information on LDTP.
 See 'LICENSE' in the source distribution for more information.
 """
 
-import ldtp
 import sys
-from .keywordgroup import KeywordGroup
-from ldtp.client_exception import LdtpExecutionError
-from ._exception import LdtpError
+try:
+    import ldtp
+except ImportError:
+    if sys.platform != "darwin":
+        raise ImportError
+    import atomac.ldtp as ldtp
+from keywordgroup import KeywordGroup
+try:
+    from ldtp.client_exception import LdtpExecutionError
+except ImportError:
+    if sys.platform != "darwin":
+        raise ImportError
+    from atomac.ldtp.client_exception import LdtpExecutionError
+from _exception import LdtpError
 from robot.api.deco import keyword
 
 try:


### PR DESCRIPTION
LDTP Library on OSX gives out an "ImportError". 

The reason for this is that ldtp on OSX uses "Atomac" and needs to be imported through atomac.ldtp